### PR TITLE
rate.current doesn't return value preceded by ,

### DIFF
--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -18,7 +18,7 @@ module.exports = function(opts) {
              if (results[3] == -1) {  // automatically recover from possible race condition
                opts.redis.expire(realKey,opts.window());
              }
-             var current = results[2];
+             var current = results[2][1];
              callback(null, {
                key: key,
                current: current,


### PR DESCRIPTION
The rate.current as of now returns a value preceded by comma due to this bug as results[2] contains [null,value].This fix will now only return the value